### PR TITLE
Add minikube support

### DIFF
--- a/03-concord-destroy.sh
+++ b/03-concord-destroy.sh
@@ -1,5 +1,10 @@
 #!/usr/bin/env bash
 
 source ./concord/setup
+if [ ! -z "${useMinikubeConfigs}" -a "${useMinikubeConfigs}" = "true" ]
+then
+    rm -rf $HOME/.kube_local
+    rm -rf $HOME/.minikube_local
+fi
 docker rm -f agent server dind ${CONCORD_DB_NAME}
 docker volume rm -f $CONCORD_DB_NAME


### PR DESCRIPTION
This commit adds configs being copied and mounted for concord agent to talk to minikube (or any cluster configs from the .kube/config)